### PR TITLE
Relax requirement that a user id be found on the server.

### DIFF
--- a/hipchat-export.py
+++ b/hipchat-export.py
@@ -278,7 +278,8 @@ def main(argv=None):
 
                 if user_id not in USER_LIST.keys():
                     print "User ID %s not found in HipChat." % (user_id)
-                    return 2
+                    print "Using id rather than name for directory"
+                    USER_SUBSET[user_id] = user_id
                 else:
                     USER_SUBSET[user_id] = USER_LIST[user_id]
 


### PR DESCRIPTION
If a user id is not found in the 100 users fetched from the server, just create the export in a directory with the userid rather than the username.